### PR TITLE
data_download plante avec le format netcdf

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "IDFDataCanada"
 uuid = "b4a361a7-a77f-4d9e-8c40-a407543557fa"
 authors = ["Gabriel Gobeil <gabriel.gobeil199@gmail.com>"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 AxisArrays = "39de3d68-74b9-583c-8d2d-e117c070f3a9"

--- a/src/functions.jl
+++ b/src/functions.jl
@@ -248,8 +248,10 @@ function data_download(output_dir::String, provinces::Array{String,N} where N, f
             rm("$(output_dir)/temp_data", recursive=true)
         end
     end
-    output_info = "$(output_dir)/info_stations.csv"
-    CSV.write(output_info, info_df)
+    if lowercase(format) == "csv"
+        output_info = "$(output_dir)/info_stations.csv"
+        CSV.write(output_info, info_df)
+    end
     return nothing
 end
 


### PR DESCRIPTION
### Description

On évite de retourner `info_df` lorsqu'on exporte les fichiers en `.nc `comme c'est seulement défini dans la portion `.csv` du code. On verra plus tard comment générer ce fichier pour ce cas-là.

### Related issue

#9 